### PR TITLE
refactor(parser): deterministic LR(0) state construction

### DIFF
--- a/plare/parser.py
+++ b/plare/parser.py
@@ -19,6 +19,7 @@ Construction pipeline (``Parser.__init__``):
 
 from __future__ import annotations
 
+from collections import deque
 from itertools import chain
 from typing import Any, Iterable, Protocol
 
@@ -562,6 +563,19 @@ def compute_follow_sets[T](
     return follow
 
 
+def _symbol_sort_key(s: Symbol) -> tuple[int, str]:
+    """Return a sort key that gives a stable total order over grammar symbols.
+
+    Terminals (token classes) sort before non-terminals (strings); within each
+    group items are ordered alphabetically by name.  This ensures that the BFS
+    expansion of each state visits successor symbols in the same order on every
+    Python run, regardless of hash randomization.
+    """
+    if isinstance(s, type):
+        return (0, s.__name__)
+    return (1, s)
+
+
 def closure[T](items: set[Item[T]], all_items: dict[str, set[Item[T]]]) -> set[Item[T]]:
     """Compute the LR(0) closure of an item set.
 
@@ -582,15 +596,15 @@ def closure[T](items: set[Item[T]], all_items: dict[str, set[Item[T]]]) -> set[I
         The closed item set (a new ``set`` that is a superset of ``items``).
     """
     items = set(items)
-    worklist = set(items)
-    while len(worklist) > 0:
-        item = worklist.pop()
+    worklist: deque[Item[T]] = deque(items)
+    while worklist:
+        item = worklist.popleft()
         next = item.next
         if next is None or isinstance(next, type):
             continue
         to_update = all_items[next] - items
-        if len(to_update) > 0:
-            worklist.update(to_update)
+        if to_update:
+            worklist.extend(to_update)
             items.update(to_update)
     return items
 
@@ -704,43 +718,54 @@ class Parser[T]:
                 all_tokens.update(t for t in right if isinstance(t, type))
 
         # ── Phase 4: Build LR(0) canonical collection ────────────────────────
-        # Start with one initial state per augmented entry rule, then expand
-        # via goto BFS until no new states are found.  ``states`` is a set so
-        # duplicate item sets (same items, different tentative id) collapse into
-        # the existing state automatically via State.__eq__.
-        states = set[State[T]]()
+        # BFS over the LR(0) automaton.  ``state_index`` maps a frozenset of
+        # items to the assigned state id, giving O(1) deduplication instead of
+        # a linear scan.  ``worklist`` is a deque so processing order is
+        # deterministic (FIFO) and independent of Python's hash randomization.
+        # Symbols leaving each state are sorted by ``_symbol_sort_key`` so state
+        # id assignment is stable across runs for the same grammar.
+        state_index: dict[frozenset[Item[T]], int] = {}
+        state_list: list[State[T]] = []
+        edges: list[tuple[State[T], Symbol, State[T]]] = []
+
+        def _intern_state(itemset: set[Item[T]]) -> tuple[State[T], bool]:
+            """Register *itemset* as a state if not yet seen; return (state, is_new)."""
+            key = frozenset(itemset)
+            if key in state_index:
+                return state_list[state_index[key]], False
+            sid = len(state_list)
+            state = State(sid, itemset)
+            state_index[key] = sid
+            state_list.append(state)
+            return state, True
+
         self.entry_state = {}
+        bfs: deque[State[T]] = deque()
         for i, (left, rule) in enumerate(entry_rules.items()):
             self.entry_state[left.orig] = i
-            states.add(State(i, closure(rule.items, all_items)))
-        edges = set[tuple[State[T], Symbol, State[T]]]()
+            init_state, _ = _intern_state(closure(rule.items, all_items))
+            bfs.append(init_state)
 
-        worklist = set(states)
-        while len(worklist) > 0:
-            logger.debug("Worklist: %d items", len(worklist))
-            state = worklist.pop()
+        while bfs:
+            state = bfs.popleft()
+            logger.debug("Worklist: %d items", len(bfs))
             logger.debug("State %d:\n%s", state.id, state)
-            nexts = {next for item in state.items if (next := item.next) is not None}
+            nexts = sorted(
+                {sym for item in state.items if (sym := item.next) is not None},
+                key=_symbol_sort_key,
+            )
             logger.debug("Nexts: %s", nexts)
-
             for symbol in nexts:
-                len_prev_states = len(states)
-                len_prev_edges = len(edges)
-
-                next_state = State(len(states), goto(state.items, symbol, all_items))
-                states.add(next_state)
-                for exist in states:
-                    if exist == next_state:
-                        next_state = exist
-                        break
-                edges.add((state, symbol, next_state))
-
-                if len(states) != len_prev_states or len(edges) != len_prev_edges:
-                    worklist.update({next_state})
+                target_state, is_new = _intern_state(
+                    goto(state.items, symbol, all_items)
+                )
+                edges.append((state, symbol, target_state))
+                if is_new:
+                    bfs.append(target_state)
 
         # ── Phase 5: Populate action/goto table ──────────────────────────────
         # Shift and Goto actions come directly from the automaton edges.
-        self.table = Table(len(states))
+        self.table = Table(len(state_list))
         for prev, symbol, next in edges:
             if isinstance(symbol, type):
                 self.table[prev.id, symbol] = Shift(next.id)
@@ -756,7 +781,7 @@ class Parser[T]:
         #     left associativity.
         #   Reduce/Reduce: prefer the higher-precedence production; raise
         #     ParserError when precedences are equal (ambiguous grammar).
-        for state in states:
+        for state in state_list:
             for item in state.items:
                 if item.next is None:
                     if item.left in start_variables:

--- a/plare/parser.py
+++ b/plare/parser.py
@@ -637,6 +637,36 @@ def goto[T](
     )
 
 
+def intern_state[T](
+    itemset: set[Item[T]],
+    state_index: dict[frozenset[Item[T]], int],
+    state_list: list[State[T]],
+) -> tuple[State[T], bool]:
+    """Register *itemset* as an LR(0) state if not yet seen; return (state, is_new).
+
+    Looks up the closed item set in *state_index* for O(1) deduplication.
+    If the itemset is new, assigns the next available id, appends a new
+    ``State`` to *state_list*, and records the mapping in *state_index*.
+
+    Args:
+        itemset: The closed item set that defines a candidate state.
+        state_index: Mapping from ``frozenset[Item]`` to already-assigned state id.
+        state_list: Ordered list of states; index equals state id.
+
+    Returns:
+        A tuple ``(state, is_new)`` where ``is_new`` is ``True`` when the
+        itemset was not previously registered.
+    """
+    key = frozenset(itemset)
+    if key in state_index:
+        return state_list[state_index[key]], False
+    sid = len(state_list)
+    state = State(sid, itemset)
+    state_index[key] = sid
+    state_list.append(state)
+    return state, True
+
+
 class Parser[T]:
     """SLR(1) parser that builds a parse table from a grammar and drives LR parsing.
 
@@ -728,22 +758,13 @@ class Parser[T]:
         state_list: list[State[T]] = []
         edges: list[tuple[State[T], Symbol, State[T]]] = []
 
-        def intern_state(itemset: set[Item[T]]) -> tuple[State[T], bool]:
-            """Register *itemset* as a state if not yet seen; return (state, is_new)."""
-            key = frozenset(itemset)
-            if key in state_index:
-                return state_list[state_index[key]], False
-            sid = len(state_list)
-            state = State(sid, itemset)
-            state_index[key] = sid
-            state_list.append(state)
-            return state, True
-
         self.entry_state = {}
         bfs: deque[State[T]] = deque()
         for i, (left, rule) in enumerate(entry_rules.items()):
             self.entry_state[left.orig] = i
-            init_state, _ = intern_state(closure(rule.items, all_items))
+            init_state, _ = intern_state(
+                closure(rule.items, all_items), state_index, state_list
+            )
             bfs.append(init_state)
 
         while bfs:
@@ -757,7 +778,7 @@ class Parser[T]:
             logger.debug("Nexts: %s", nexts)
             for symbol in nexts:
                 target_state, is_new = intern_state(
-                    goto(state.items, symbol, all_items)
+                    goto(state.items, symbol, all_items), state_index, state_list
                 )
                 edges.append((state, symbol, target_state))
                 if is_new:

--- a/plare/parser.py
+++ b/plare/parser.py
@@ -563,7 +563,7 @@ def compute_follow_sets[T](
     return follow
 
 
-def _symbol_sort_key(s: Symbol) -> tuple[int, str]:
+def symbol_sort_key(s: Symbol) -> tuple[int, str]:
     """Return a sort key that gives a stable total order over grammar symbols.
 
     Terminals (token classes) sort before non-terminals (strings); within each
@@ -722,13 +722,13 @@ class Parser[T]:
         # items to the assigned state id, giving O(1) deduplication instead of
         # a linear scan.  ``worklist`` is a deque so processing order is
         # deterministic (FIFO) and independent of Python's hash randomization.
-        # Symbols leaving each state are sorted by ``_symbol_sort_key`` so state
+        # Symbols leaving each state are sorted by ``symbol_sort_key`` so state
         # id assignment is stable across runs for the same grammar.
         state_index: dict[frozenset[Item[T]], int] = {}
         state_list: list[State[T]] = []
         edges: list[tuple[State[T], Symbol, State[T]]] = []
 
-        def _intern_state(itemset: set[Item[T]]) -> tuple[State[T], bool]:
+        def intern_state(itemset: set[Item[T]]) -> tuple[State[T], bool]:
             """Register *itemset* as a state if not yet seen; return (state, is_new)."""
             key = frozenset(itemset)
             if key in state_index:
@@ -743,7 +743,7 @@ class Parser[T]:
         bfs: deque[State[T]] = deque()
         for i, (left, rule) in enumerate(entry_rules.items()):
             self.entry_state[left.orig] = i
-            init_state, _ = _intern_state(closure(rule.items, all_items))
+            init_state, _ = intern_state(closure(rule.items, all_items))
             bfs.append(init_state)
 
         while bfs:
@@ -752,11 +752,11 @@ class Parser[T]:
             logger.debug("State %d:\n%s", state.id, state)
             nexts = sorted(
                 {sym for item in state.items if (sym := item.next) is not None},
-                key=_symbol_sort_key,
+                key=symbol_sort_key,
             )
             logger.debug("Nexts: %s", nexts)
             for symbol in nexts:
-                target_state, is_new = _intern_state(
+                target_state, is_new = intern_state(
                     goto(state.items, symbol, all_items)
                 )
                 edges.append((state, symbol, target_state))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,5 +48,10 @@ include = [
     "/plare/"
 ]
 
+[tool.pytest.ini_options]
+markers = [
+    "slow: marks tests as slow-running (deselect with '-m \"not slow\"')",
+]
+
 [tool.isort]
 profile = "black"

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -1,0 +1,176 @@
+"""Tests that Parser produces identical state ids and table contents on repeated builds.
+
+Determinism means: for the same grammar input, two independently constructed
+Parser objects must assign the same entry_state ids and the same action/goto
+entries in every table cell.  Without explicit ordering in the BFS expansion,
+Python's hash randomization can produce different state id assignments across
+runs.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from plare.parser import Parser
+from plare.token import Token
+
+# ---------------------------------------------------------------------------
+# Shared token and AST types for a multi-state expression grammar
+# ---------------------------------------------------------------------------
+
+
+class PLUS_D(Token):
+    precedence = 1
+    associative = "left"
+
+
+class STAR_D(Token):
+    precedence = 2
+    associative = "left"
+
+
+class NUM_D(Token):
+    pass
+
+
+class LPAREN_D(Token):
+    pass
+
+
+class RPAREN_D(Token):
+    pass
+
+
+class Num:
+    def __init__(self, tok: NUM_D) -> None:
+        self.tok = tok
+
+
+class Add:
+    def __init__(self, left: object, right: object) -> None:
+        self.left = left
+        self.right = right
+
+
+class Mul:
+    def __init__(self, left: object, right: object) -> None:
+        self.left = left
+        self.right = right
+
+
+def make_expr_grammar() -> (
+    dict[str, list[tuple[list[type[Token] | str], type | None, list[int]]]]
+):
+    """Return a classic expression grammar with enough states to be meaningful.
+
+    expr → expr PLUS term | term
+    term → term STAR factor | factor
+    factor → NUM | LPAREN expr RPAREN
+
+    This produces around 20 LR(0) states, spanning shift, reduce, goto, and
+    accept entries.  Multiple entry points (expr and term) ensure that the
+    entry_state mapping is also exercised.
+    """
+    return {
+        "expr": [
+            (["expr", PLUS_D, "term"], Add, [0, 2]),
+            (["term"], None, [0]),
+        ],
+        "term": [
+            (["term", STAR_D, "factor"], Mul, [0, 2]),
+            (["factor"], None, [0]),
+        ],
+        "factor": [
+            ([NUM_D], Num, [0]),
+            ([LPAREN_D, "expr", RPAREN_D], None, [1]),
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Determinism tests
+# ---------------------------------------------------------------------------
+
+
+def test_parser_entry_state_is_deterministic() -> None:
+    """Two Parser instances built from identical grammars have the same entry_state."""
+    p1 = Parser(make_expr_grammar())
+    p2 = Parser(make_expr_grammar())
+    assert p1.entry_state == p2.entry_state
+
+
+def test_parser_table_actions_are_deterministic() -> None:
+    """Two Parser instances built from identical grammars have identical action tables.
+
+    Compares every cell by its string representation so the test does not rely
+    on Action subclass identity.
+    """
+    p1 = Parser(make_expr_grammar())
+    p2 = Parser(make_expr_grammar())
+
+    assert len(p1.table.table) == len(p2.table.table), "table row count differs"
+    for state_id, (row1, row2) in enumerate(zip(p1.table.table, p2.table.table)):
+        assert set(row1.keys()) == set(
+            row2.keys()
+        ), f"state {state_id}: key sets differ"
+        for sym in row1:
+            assert str(row1[sym]) == str(
+                row2[sym]
+            ), f"state {state_id}, symbol {sym}: {row1[sym]!r} != {row2[sym]!r}"
+
+
+# ---------------------------------------------------------------------------
+# Build-time measurement for 50-rule grammar (provides HANDOFF timing data)
+# ---------------------------------------------------------------------------
+
+
+def make_chain_grammar(
+    depth: int,
+) -> dict[str, list[tuple[list[type[Token] | str], type | None, list[int]]]]:
+    """Return a right-recursive chain grammar with ``depth`` levels.
+
+    Each level i has a unique token class ChainTok_i so the grammar produces
+    O(depth) LR(0) states.  Used to measure parser build time at scale.
+    """
+    token_classes: list[type[Token]] = []
+    for i in range(depth + 1):
+        cls = type(f"ChainTok_{i}", (Token,), {})
+        token_classes.append(cls)
+
+    class ChainNode:
+        def __init__(self, *args: object) -> None:
+            pass
+
+    grammar: dict[str, list[tuple[list[type[Token] | str], type | None, list[int]]]] = (
+        {}
+    )
+    for i in range(depth):
+        tok = token_classes[i]
+        next_nt = f"level_{i + 1}"
+        grammar[f"level_{i}"] = [
+            ([tok, next_nt], ChainNode, [0, 1]),
+            ([tok], ChainNode, [0]),
+        ]
+    grammar[f"level_{depth}"] = [
+        ([token_classes[depth]], ChainNode, [0]),
+    ]
+    return grammar
+
+
+@pytest.mark.slow
+def test_parser_build_time_large_grammar() -> None:
+    """Build a 50-level chain grammar and record the wall time.
+
+    This test does not assert a specific time bound (build times vary by
+    hardware).  Its purpose is to produce a timing measurement for the T3
+    HANDOFF.md Notes section.  Marked slow so it can be skipped in fast CI
+    runs with ``pytest -m 'not slow'``.
+    """
+    grammar = make_chain_grammar(50)
+    start = time.perf_counter()
+    p = Parser(grammar)
+    elapsed = time.perf_counter() - start
+    assert p.entry_state, "parser must have at least one entry state"
+    print(f"\nLarge grammar (50 levels) build time: {elapsed * 1000:.1f} ms")


### PR DESCRIPTION
## Summary

- Replace the `set`-based BFS worklist in `Parser.__init__` Phase 4 with a
  `collections.deque` (FIFO), eliminating non-determinism from `set.pop()`.
- Replace the O(n) linear scan for state deduplication with a
  `dict[frozenset[Item], int]` index, giving O(1) lookup and making state id
  assignment stable across Python runs.
- Add `symbol_sort_key()` (module-level) to sort each state's outgoing symbols
  (terminals before non-terminals, then alphabetically) so BFS traversal order
  is deterministic regardless of hash randomization.
- Replace the `set`-based edge collection with a `list`; no duplicates are
  possible under BFS so a set is unnecessary.
- Extract `intern_state()` as a module-level function (was a nested function
  inside `__init__`); takes `state_index` and `state_list` as explicit
  parameters.
- Add `tests/test_determinism.py` with two correctness tests (identical
  `entry_state` and identical action table across two independent builds of the
  same grammar) and one `@pytest.mark.slow` build-time test for a 50-level
  chain grammar (2.7 ms on dev machine).
- Register the `slow` pytest mark in `pyproject.toml`.

## Test plan

- `pytest -q` → `24 passed, 2 xfailed`
- `pyright plare/` → 0 errors
- `black --check plare/ tests/` → no reformats
- `python examples/calc/calc.py examples/calc/data/ex01.calc` prints `2`
- `python examples/sum_of_list/sum.py "[1, 2, 3, 4, 5]"` prints `15`

🤖 Generated with [Claude Code](https://claude.com/claude-code)