### PR TITLE
refactor: improve hash implementations for Item, State, and Token

### DIFF
--- a/plare/parser.py
+++ b/plare/parser.py
@@ -195,7 +195,7 @@ class Item[T]:
         return f"{self.left} {arrow} {before_dot} . {after_dot}"
 
     def __hash__(self) -> int:
-        return hash(self.left) + sum(map(hash, self.right)) + hash(self.loc)
+        return hash((self.left, tuple(self.right), self.loc))
 
     def __eq__(self, value: Any) -> bool:
         return (

--- a/plare/parser.py
+++ b/plare/parser.py
@@ -222,7 +222,7 @@ class State[T]:
         self.items = items
 
     def __hash__(self) -> int:
-        return sum(map(hash, (item for item in self.items)))
+        return hash(frozenset(self.items))
 
     def __eq__(self, other: State[T] | Any) -> bool:
         return isinstance(other, State) and self.items == other.items

--- a/plare/token.py
+++ b/plare/token.py
@@ -45,7 +45,9 @@ class Token:
         identity-by-source-position contract — it is intentional and does *not*
         compare token values.  The parser itself only cares about token *classes*,
         not instances, so this contract is used only in tests and edge-case
-        bookkeeping, not in the core parse loop.
+        bookkeeping, not in the core parse loop.  The hash incorporates the token
+        class, so instances of different subclasses at the same source position
+        have different hashes.
     """
 
     associative: assoc = "left"
@@ -63,7 +65,7 @@ class Token:
         self.offset = offset
 
     def __hash__(self) -> int:
-        return hash(self.lineno) + hash(self.offset)
+        return hash((type(self), self.lineno, self.offset))
 
     def __eq__(self, other: Any) -> bool:
         return (

--- a/tests/test_hash_semantics.py
+++ b/tests/test_hash_semantics.py
@@ -1,0 +1,65 @@
+"""Tests for Item, State, and Token hash and equality contracts."""
+
+from __future__ import annotations
+
+from plare.parser import IDMaker, Item, State
+from plare.token import Token
+
+
+class TokA(Token):
+    def __init__(self, value: str, *, lineno: int, offset: int) -> None:
+        self.lineno = lineno
+        self.offset = offset
+
+
+class TokB(Token):
+    def __init__(self, value: str, *, lineno: int, offset: int) -> None:
+        self.lineno = lineno
+        self.offset = offset
+
+
+def make_item(left: str, right: list, loc: int = 0) -> Item[object]:
+    return Item(left, right, IDMaker(0), loc)
+
+
+def test_item_equal_data_hash_equal() -> None:
+    a = make_item("E", [TokA, "T"], loc=1)
+    b = make_item("E", [TokA, "T"], loc=1)
+
+    assert a == b
+    assert hash(a) == hash(b)
+
+
+def test_item_different_right_order_hash_different() -> None:
+    a = make_item("E", [TokA, TokB])
+    b = make_item("E", [TokB, TokA])
+
+    assert a != b
+    assert hash(a) != hash(b)
+
+
+def test_state_equal_items_hash_equal() -> None:
+    item_a = make_item("E", [TokA], loc=0)
+    item_b = make_item("E", [TokA], loc=0)
+
+    s1 = State(0, {item_a})
+    s2 = State(1, {item_b})
+
+    assert s1 == s2
+    assert hash(s1) == hash(s2)
+
+
+def test_token_hash_includes_class() -> None:
+    a = TokA("x", lineno=1, offset=0)
+    b = TokB("x", lineno=1, offset=0)
+
+    assert a != b
+    assert hash(a) != hash(b)
+
+
+def test_token_same_class_same_position_equal() -> None:
+    a = TokA("x", lineno=3, offset=5)
+    b = TokA("y", lineno=3, offset=5)
+
+    assert a == b
+    assert hash(a) == hash(b)


### PR DESCRIPTION
## Summary

- `Item.__hash__`: sum-based → tuple-based (`hash((self.left, tuple(self.right), self.loc))`).
  Fixes an order-insensitivity bug where `[A, B]` and `[B, A]` in the RHS produced equal hashes.
- `State.__hash__`: sum-based → frozenset-based (`hash(frozenset(self.items))`),
  consistent with the `frozenset[Item]` cache key already used by `intern_state` (T3).
- `Token.__hash__`: now includes `type(self)` — `hash((type(self), self.lineno, self.offset))`.
  The equality contract already incorporates the class via `isinstance(other, self.__class__)`;
  the hash now matches. Added one sentence to the docstring to make this explicit.
  Existing subclass overrides (`hash(self.value) + super().__hash__()`) remain correct.

## Tests

Added `tests/test_hash_semantics.py` (5 tests):

- `test_item_equal_data_hash_equal` — independently constructed equal Items are `==` and share a hash
- `test_item_different_right_order_hash_different` — validates the tuple-based fix
- `test_state_equal_items_hash_equal` — equal item sets produce equal State hashes
- `test_token_hash_includes_class` — different subclasses at the same position hash differently
- `test_token_same_class_same_position_equal` — regression: same class + position → equal

## Result

`29 passed, 2 xfailed` — pyright clean, black/isort unchanged.