### PR TITLE
refactor(parser): use rightmost terminal for production precedence

### DIFF
--- a/plare/parser.py
+++ b/plare/parser.py
@@ -151,15 +151,10 @@ class Item[T]:
         self.maker = maker
         self.precedence = 0
         terminals = [t for t in right if isinstance(t, type)]
-        for token in terminals:
-            if token.precedence > 0:
+        for token in reversed(terminals):
+            if token.precedence != 0:
                 self.precedence = token.precedence
                 break
-        else:
-            for token in terminals:
-                if token.precedence < 0:
-                    self.precedence = token.precedence
-                    break
 
     @property
     def next(self) -> Symbol | None:


### PR DESCRIPTION
## Summary

- `Item.__init__` in `plare/parser.py` previously scanned terminals
  left-to-right and picked the first non-zero-precedence terminal as the
  production's effective precedence.
- Changed to scan right-to-left (`reversed`) and pick the **last**
  non-zero-precedence terminal instead.
- The two-phase loop (positive precedence first, then negative) is
  collapsed into a single `!= 0` check.

## Motivation

yacc/bison defines a production's default precedence as that of its
rightmost terminal. Matching this convention ensures that grammars
written with yacc-style token declarations behave identically in plare.

In practice, most productions have a single operator terminal, so this
change has no effect on existing grammars or tests. The difference only
surfaces when a production contains two or more terminals with different
declared precedences.

## Breaking change

The original two-phase scan gave positive-precedence terminals priority
over negative ones regardless of position. For example, a production
`[A(prec=1), B(prec=-1)]` previously resolved to prec=1 (positive wins);
it now resolves to prec=-1 (last non-zero wins).

Negative precedence is not part of the yacc/bison specification and is
not used in any existing grammar or test in this codebase. The priority
hierarchy between positive and negative precedence is therefore removed.

## Test plan

- [x] `pytest -q` — 29 passed, 2 xfailed (unchanged)
- [x] `pyright plare/` — 0 errors
- [x] `black --check . && isort --check .` — no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)