### PR TITLE
feat(parser): support prec_token override in grammar entries

### DIFF
--- a/plare/parser.py
+++ b/plare/parser.py
@@ -115,12 +115,10 @@ class Item[T]:
     indicating how much of the RHS has been recognised so far.  Items are the
     building blocks of LR automaton states.
 
-    The ``precedence`` attribute is computed at construction time as the
-    precedence of the *first* terminal in ``right`` with a non-zero precedence
-    value (positive terminals take priority over negative ones).  This is used
-    for shift/reduce conflict resolution.  NOTE: per the T5 spec this will be
-    changed to the *last* terminal — the current behaviour matches yacc/bison
-    only for simple grammars.
+    ``precedence`` is used for shift/reduce conflict resolution.  By default it
+    is the precedence of the *rightmost* terminal in ``right`` with a non-zero
+    precedence value (yacc/bison convention).  When ``prec_override`` is given
+    (analogous to yacc's ``%prec``), it replaces that derivation entirely.
 
     Attributes:
         left: The non-terminal on the LHS of the rule.
@@ -130,6 +128,9 @@ class Item[T]:
         maker: The semantic action to invoke on reduction.
         precedence: Effective precedence of this production for conflict
             resolution; ``0`` means no precedence.
+        prec_override: When not ``None``, this value was supplied explicitly
+            via a ``prec_token`` in the grammar tuple and overrides the
+            terminal-scan precedence.
     """
 
     left: str | StartVariable
@@ -137,6 +138,7 @@ class Item[T]:
     loc: int
     maker: Maker[T]
     precedence: int
+    prec_override: int | None
 
     def __init__(
         self,
@@ -144,17 +146,22 @@ class Item[T]:
         right: list[Symbol],
         maker: Maker[T],
         loc: int = 0,
+        prec_override: int | None = None,
     ) -> None:
         self.left = left
         self.right = right
         self.loc = loc
         self.maker = maker
-        self.precedence = 0
-        terminals = [t for t in right if isinstance(t, type)]
-        for token in reversed(terminals):
-            if token.precedence != 0:
-                self.precedence = token.precedence
-                break
+        self.prec_override = prec_override
+        if prec_override is not None:
+            self.precedence = prec_override
+        else:
+            self.precedence = 0
+            terminals = [t for t in right if isinstance(t, type)]
+            for token in reversed(terminals):
+                if token.precedence != 0:
+                    self.precedence = token.precedence
+                    break
 
     @property
     def next(self) -> Symbol | None:
@@ -170,6 +177,7 @@ class Item[T]:
                 self.right,
                 self.maker,
                 self.loc + 1,
+                prec_override=self.prec_override,
             )
         return None
 
@@ -396,19 +404,23 @@ class Rule[T]:
     """
 
     left: str
-    rights: list[tuple[list[Symbol], Maker[T]]]
+    rights: list[tuple[list[Symbol], Maker[T], int | None]]
     first: set[type[Token]]
     follow: set[type[Token]]
 
     def __init__(
         self,
         left: str,
-        rights: list[tuple[list[Symbol], type[T] | None, list[int]]],
+        rights: list[tuple[list[Symbol], type[T] | None, list[int], int | None]],
     ) -> None:
         self.left = left
         self.rights = [
-            (right, TMaker(action, args) if action is not None else IDMaker(*args))
-            for right, action, args in rights
+            (
+                right,
+                TMaker(action, args) if action is not None else IDMaker(*args),
+                prec_override,
+            )
+            for right, action, args, prec_override in rights
         ]
         self.first_built = False
         self.follow_built = False
@@ -458,7 +470,10 @@ class Rule[T]:
     @property
     def items(self) -> set[Item[T]]:
         """Initial items ``[A → • rhs]`` for all alternatives of this rule."""
-        return set(Item(self.left, right, maker) for right, maker in self.rights)
+        return set(
+            Item(self.left, right, maker, prec_override=prec_override)
+            for right, maker, prec_override in self.rights
+        )
 
 
 def compute_first_sets[T](rules: dict[str, Rule[T]]) -> dict[str, set[type[Token]]]:
@@ -479,7 +494,7 @@ def compute_first_sets[T](rules: dict[str, Rule[T]]) -> dict[str, set[type[Token
     while changed:
         changed = False
         for name, rule in rules.items():
-            for right, _ in rule.rights:
+            for right, _, _prec in rule.rights:
                 if not right:
                     if EPSILON not in first[name]:
                         first[name].add(EPSILON)
@@ -532,7 +547,7 @@ def compute_follow_sets[T](
     while changed:
         changed = False
         for lhs, rule in rules.items():
-            for right, _ in rule.rights:
+            for right, _, _prec in rule.rights:
                 for i, sym in enumerate(right):
                     if not isinstance(sym, str):
                         continue
@@ -698,7 +713,10 @@ class Parser[T]:
         self,
         grammar: dict[
             str,
-            list[tuple[list[type[Token] | str], type[T] | None, list[int]]],
+            list[
+                tuple[list[type[Token] | str], type[T] | None, list[int]]
+                | tuple[list[type[Token] | str], type[T] | None, list[int], type[Token]]
+            ],
         ],
     ) -> None:
         # ── Phase 1: Augment grammar ─────────────────────────────────────────
@@ -707,13 +725,38 @@ class Parser[T]:
         # so the parser has a distinguished start state per entry point.
         # Using StartVariable ensures these rules are never confused with
         # user-defined rules, even if a user names a rule identically.
+        #
+        # Normalize each grammar tuple to the internal 4-element form
+        # (right, action, args, prec_override).  The optional 4th element in a
+        # user-supplied tuple is a token *class* whose precedence overrides the
+        # production's effective precedence (analogous to yacc's %prec).
+        normalized: dict[
+            str,
+            list[tuple[list[type[Token] | str], type[T] | None, list[int], int | None]],
+        ] = {}
+        for left, rights in grammar.items():
+            norm_rights: list[
+                tuple[list[type[Token] | str], type[T] | None, list[int], int | None]
+            ] = []
+            for entry in rights:
+                if len(entry) == 4:
+                    right, action, args, prec_token = entry
+                    prec_override: int | None = prec_token.precedence
+                else:
+                    right, action, args = entry
+                    prec_override = None
+                norm_rights.append((right, action, args, prec_override))
+            normalized[left] = norm_rights
+
         entry_rules = {
-            StartVariable(left): Rule[T](StartVariable(left), [([left], None, [0])])
+            StartVariable(left): Rule[T](
+                StartVariable(left), [([left], None, [0], None)]
+            )
             for left in grammar.keys()
         }
         start_variables = set(entry_rules.keys())
 
-        rules = {left: Rule[T](left, rights) for left, rights in grammar.items()}
+        rules = {left: Rule[T](left, rights) for left, rights in normalized.items()}
         rules |= entry_rules
 
         # ── Phase 2: Compute FIRST sets ──────────────────────────────────────
@@ -739,7 +782,7 @@ class Parser[T]:
         all_items = {left: rule.items for left, rule in rules.items()}
         all_tokens = set[type[Token]]()
         for rule in rules.values():
-            for right, _ in rule.rights:
+            for right, _, _prec in rule.rights:
                 all_tokens.update(t for t in right if isinstance(t, type))
 
         # ── Phase 4: Build LR(0) canonical collection ────────────────────────

--- a/plare/parser.py
+++ b/plare/parser.py
@@ -399,28 +399,31 @@ class Rule[T]:
     """
 
     left: str
-    rights: list[tuple[list[Symbol], Maker[T]] | tuple[list[Symbol], Maker[T], int]]
+    rights: list[tuple[list[Symbol], Maker[T], int | None]]
     first: set[type[Token]]
     follow: set[type[Token]]
 
     def __init__(
         self,
         left: str,
-        rights: list[tuple[list[Symbol], type[T] | None, list[int], int | None]],
+        rights: list[
+            tuple[list[Symbol], type[T] | None, list[int]]
+            | tuple[list[Symbol], type[T] | None, list[int], int]
+        ],
     ) -> None:
         self.left = left
-        built: list[
-            tuple[list[Symbol], Maker[T]] | tuple[list[Symbol], Maker[T], int]
-        ] = []
-        for right, action, args, prec_override in rights:
-            maker: Maker[T] = (
-                TMaker(action, args) if action is not None else IDMaker(*args)
+        self.rights = [
+            (
+                entry[0],
+                (
+                    TMaker(entry[1], entry[2])
+                    if entry[1] is not None
+                    else IDMaker(*entry[2])
+                ),
+                entry[3] if len(entry) == 4 else None,
             )
-            if prec_override is not None:
-                built.append((right, maker, prec_override))
-            else:
-                built.append((right, maker))
-        self.rights = built
+            for entry in rights
+        ]
         self.first_built = False
         self.follow_built = False
 
@@ -469,12 +472,10 @@ class Rule[T]:
     @property
     def items(self) -> set[Item[T]]:
         """Initial items ``[A → • rhs]`` for all alternatives of this rule."""
-        result: set[Item[T]] = set()
-        for entry in self.rights:
-            right, maker = entry[0], entry[1]
-            prec_override = entry[2] if len(entry) == 3 else None
-            result.add(Item(self.left, right, maker, prec_override=prec_override))
-        return result
+        return set(
+            Item(self.left, right, maker, prec_override=prec_override)
+            for right, maker, prec_override in self.rights
+        )
 
 
 def compute_first_sets[T](rules: dict[str, Rule[T]]) -> dict[str, set[type[Token]]]:
@@ -495,7 +496,7 @@ def compute_first_sets[T](rules: dict[str, Rule[T]]) -> dict[str, set[type[Token
     while changed:
         changed = False
         for name, rule in rules.items():
-            for right, *_ in rule.rights:
+            for right, _, _prec in rule.rights:
                 if not right:
                     if EPSILON not in first[name]:
                         first[name].add(EPSILON)
@@ -548,7 +549,7 @@ def compute_follow_sets[T](
     while changed:
         changed = False
         for lhs, rule in rules.items():
-            for right, *_ in rule.rights:
+            for right, _, _prec in rule.rights:
                 for i, sym in enumerate(right):
                     if not isinstance(sym, str):
                         continue
@@ -727,32 +728,33 @@ class Parser[T]:
         # Using StartVariable ensures these rules are never confused with
         # user-defined rules, even if a user names a rule identically.
         #
-        # Normalize each grammar tuple to the internal 4-element form
-        # (right, action, args, prec_override).  The optional 4th element in a
-        # user-supplied tuple is a token *class* whose precedence overrides the
-        # production's effective precedence (analogous to yacc's %prec).
+        # Resolve the optional 4th element (prec_token) in each grammar tuple.
+        # A 3-tuple (right, action, args) is passed through unchanged; a 4-tuple
+        # (right, action, args, prec_token) is rewritten to
+        # (right, action, args, prec_token.precedence) so Rule.__init__ receives
+        # a plain int override rather than a token class.
         normalized: dict[
             str,
-            list[tuple[list[type[Token] | str], type[T] | None, list[int], int | None]],
+            list[
+                tuple[list[type[Token] | str], type[T] | None, list[int]]
+                | tuple[list[type[Token] | str], type[T] | None, list[int], int]
+            ],
         ] = {}
         for left, rights in grammar.items():
             norm_rights: list[
-                tuple[list[type[Token] | str], type[T] | None, list[int], int | None]
+                tuple[list[type[Token] | str], type[T] | None, list[int]]
+                | tuple[list[type[Token] | str], type[T] | None, list[int], int]
             ] = []
             for entry in rights:
                 if len(entry) == 4:
                     right, action, args, prec_token = entry
-                    prec_override: int | None = prec_token.precedence
+                    norm_rights.append((right, action, args, prec_token.precedence))
                 else:
-                    right, action, args = entry
-                    prec_override = None
-                norm_rights.append((right, action, args, prec_override))
+                    norm_rights.append(entry)
             normalized[left] = norm_rights
 
         entry_rules = {
-            StartVariable(left): Rule[T](
-                StartVariable(left), [([left], None, [0], None)]
-            )
+            StartVariable(left): Rule[T](StartVariable(left), [([left], None, [0])])
             for left in grammar.keys()
         }
         start_variables = set(entry_rules.keys())
@@ -783,7 +785,7 @@ class Parser[T]:
         all_items = {left: rule.items for left, rule in rules.items()}
         all_tokens = set[type[Token]]()
         for rule in rules.values():
-            for right, *_ in rule.rights:
+            for right, _, _prec in rule.rights:
                 all_tokens.update(t for t in right if isinstance(t, type))
 
         # ── Phase 4: Build LR(0) canonical collection ────────────────────────

--- a/plare/parser.py
+++ b/plare/parser.py
@@ -399,7 +399,7 @@ class Rule[T]:
     """
 
     left: str
-    rights: list[tuple[list[Symbol], Maker[T], int | None]]
+    rights: list[tuple[list[Symbol], Maker[T]] | tuple[list[Symbol], Maker[T], int]]
     first: set[type[Token]]
     follow: set[type[Token]]
 
@@ -409,14 +409,18 @@ class Rule[T]:
         rights: list[tuple[list[Symbol], type[T] | None, list[int], int | None]],
     ) -> None:
         self.left = left
-        self.rights = [
-            (
-                right,
-                TMaker(action, args) if action is not None else IDMaker(*args),
-                prec_override,
+        built: list[
+            tuple[list[Symbol], Maker[T]] | tuple[list[Symbol], Maker[T], int]
+        ] = []
+        for right, action, args, prec_override in rights:
+            maker: Maker[T] = (
+                TMaker(action, args) if action is not None else IDMaker(*args)
             )
-            for right, action, args, prec_override in rights
-        ]
+            if prec_override is not None:
+                built.append((right, maker, prec_override))
+            else:
+                built.append((right, maker))
+        self.rights = built
         self.first_built = False
         self.follow_built = False
 
@@ -465,10 +469,12 @@ class Rule[T]:
     @property
     def items(self) -> set[Item[T]]:
         """Initial items ``[A → • rhs]`` for all alternatives of this rule."""
-        return set(
-            Item(self.left, right, maker, prec_override=prec_override)
-            for right, maker, prec_override in self.rights
-        )
+        result: set[Item[T]] = set()
+        for entry in self.rights:
+            right, maker = entry[0], entry[1]
+            prec_override = entry[2] if len(entry) == 3 else None
+            result.add(Item(self.left, right, maker, prec_override=prec_override))
+        return result
 
 
 def compute_first_sets[T](rules: dict[str, Rule[T]]) -> dict[str, set[type[Token]]]:
@@ -489,7 +495,7 @@ def compute_first_sets[T](rules: dict[str, Rule[T]]) -> dict[str, set[type[Token
     while changed:
         changed = False
         for name, rule in rules.items():
-            for right, _, _prec in rule.rights:
+            for right, *_ in rule.rights:
                 if not right:
                     if EPSILON not in first[name]:
                         first[name].add(EPSILON)
@@ -542,7 +548,7 @@ def compute_follow_sets[T](
     while changed:
         changed = False
         for lhs, rule in rules.items():
-            for right, _, _prec in rule.rights:
+            for right, *_ in rule.rights:
                 for i, sym in enumerate(right):
                     if not isinstance(sym, str):
                         continue
@@ -777,7 +783,7 @@ class Parser[T]:
         all_items = {left: rule.items for left, rule in rules.items()}
         all_tokens = set[type[Token]]()
         for rule in rules.values():
-            for right, _, _prec in rule.rights:
+            for right, *_ in rule.rights:
                 all_tokens.update(t for t in right if isinstance(t, type))
 
         # ── Phase 4: Build LR(0) canonical collection ────────────────────────

--- a/plare/parser.py
+++ b/plare/parser.py
@@ -128,9 +128,6 @@ class Item[T]:
         maker: The semantic action to invoke on reduction.
         precedence: Effective precedence of this production for conflict
             resolution; ``0`` means no precedence.
-        prec_override: When not ``None``, this value was supplied explicitly
-            via a ``prec_token`` in the grammar tuple and overrides the
-            terminal-scan precedence.
     """
 
     left: str | StartVariable
@@ -138,7 +135,6 @@ class Item[T]:
     loc: int
     maker: Maker[T]
     precedence: int
-    prec_override: int | None
 
     def __init__(
         self,
@@ -152,7 +148,6 @@ class Item[T]:
         self.right = right
         self.loc = loc
         self.maker = maker
-        self.prec_override = prec_override
         if prec_override is not None:
             self.precedence = prec_override
         else:
@@ -177,7 +172,7 @@ class Item[T]:
                 self.right,
                 self.maker,
                 self.loc + 1,
-                prec_override=self.prec_override,
+                prec_override=self.precedence,
             )
         return None
 

--- a/plare/parser.py
+++ b/plare/parser.py
@@ -406,23 +406,16 @@ class Rule[T]:
     def __init__(
         self,
         left: str,
-        rights: list[
-            tuple[list[Symbol], type[T] | None, list[int]]
-            | tuple[list[Symbol], type[T] | None, list[int], int]
-        ],
+        rights: list[tuple[list[Symbol], type[T] | None, list[int], int | None]],
     ) -> None:
         self.left = left
         self.rights = [
             (
-                entry[0],
-                (
-                    TMaker(entry[1], entry[2])
-                    if entry[1] is not None
-                    else IDMaker(*entry[2])
-                ),
-                entry[3] if len(entry) == 4 else None,
+                right,
+                TMaker(action, args) if action is not None else IDMaker(*args),
+                prec_override,
             )
-            for entry in rights
+            for right, action, args, prec_override in rights
         ]
         self.first_built = False
         self.follow_built = False
@@ -735,26 +728,25 @@ class Parser[T]:
         # a plain int override rather than a token class.
         normalized: dict[
             str,
-            list[
-                tuple[list[type[Token] | str], type[T] | None, list[int]]
-                | tuple[list[type[Token] | str], type[T] | None, list[int], int]
-            ],
+            list[tuple[list[type[Token] | str], type[T] | None, list[int], int | None]],
         ] = {}
         for left, rights in grammar.items():
             norm_rights: list[
-                tuple[list[type[Token] | str], type[T] | None, list[int]]
-                | tuple[list[type[Token] | str], type[T] | None, list[int], int]
+                tuple[list[type[Token] | str], type[T] | None, list[int], int | None]
             ] = []
             for entry in rights:
                 if len(entry) == 4:
                     right, action, args, prec_token = entry
                     norm_rights.append((right, action, args, prec_token.precedence))
                 else:
-                    norm_rights.append(entry)
+                    right, action, args = entry
+                    norm_rights.append((right, action, args, None))
             normalized[left] = norm_rights
 
         entry_rules = {
-            StartVariable(left): Rule[T](StartVariable(left), [([left], None, [0])])
+            StartVariable(left): Rule[T](
+                StartVariable(left), [([left], None, [0], None)]
+            )
             for left in grammar.keys()
         }
         start_variables = set(entry_rules.keys())

--- a/plare/parser.py
+++ b/plare/parser.py
@@ -496,7 +496,7 @@ def compute_first_sets[T](rules: dict[str, Rule[T]]) -> dict[str, set[type[Token
     while changed:
         changed = False
         for name, rule in rules.items():
-            for right, _, _prec in rule.rights:
+            for right, _, _ in rule.rights:
                 if not right:
                     if EPSILON not in first[name]:
                         first[name].add(EPSILON)
@@ -549,7 +549,7 @@ def compute_follow_sets[T](
     while changed:
         changed = False
         for lhs, rule in rules.items():
-            for right, _, _prec in rule.rights:
+            for right, _, _ in rule.rights:
                 for i, sym in enumerate(right):
                     if not isinstance(sym, str):
                         continue
@@ -785,7 +785,7 @@ class Parser[T]:
         all_items = {left: rule.items for left, rule in rules.items()}
         all_tokens = set[type[Token]]()
         for rule in rules.values():
-            for right, _, _prec in rule.rights:
+            for right, _, _ in rule.rights:
                 all_tokens.update(t for t in right if isinstance(t, type))
 
         # ── Phase 4: Build LR(0) canonical collection ────────────────────────

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -16,6 +16,14 @@ import pytest
 from plare.parser import Parser
 from plare.token import Token
 
+type Grammar = dict[
+    str,
+    list[
+        tuple[list[type[Token] | str], type | None, list[int]]
+        | tuple[list[type[Token] | str], type | None, list[int], type[Token]]
+    ],
+]
+
 # ---------------------------------------------------------------------------
 # Shared token and AST types for a multi-state expression grammar
 # ---------------------------------------------------------------------------
@@ -60,9 +68,7 @@ class Mul:
         self.right = right
 
 
-def make_expr_grammar() -> (
-    dict[str, list[tuple[list[type[Token] | str], type | None, list[int]]]]
-):
+def make_expr_grammar() -> Grammar:
     """Return a classic expression grammar with enough states to be meaningful.
 
     expr → expr PLUS term | term
@@ -128,7 +134,7 @@ def test_parser_table_actions_are_deterministic() -> None:
 
 def make_chain_grammar(
     depth: int,
-) -> dict[str, list[tuple[list[type[Token] | str], type | None, list[int]]]]:
+) -> Grammar:
     """Return a right-recursive chain grammar with ``depth`` levels.
 
     Each level i has a unique token class ChainTok_i so the grammar produces
@@ -143,9 +149,7 @@ def make_chain_grammar(
         def __init__(self, *args: object) -> None:
             pass
 
-    grammar: dict[str, list[tuple[list[type[Token] | str], type | None, list[int]]]] = (
-        {}
-    )
+    grammar: Grammar = {}
     for i in range(depth):
         tok = token_classes[i]
         next_nt = f"level_{i + 1}"

--- a/tests/test_first_follow.py
+++ b/tests/test_first_follow.py
@@ -97,7 +97,7 @@ class RParen(Token):
 
 def make_rule(left: str, rights: list[list[Symbol]]) -> Rule[Null]:
     """Build a Rule for testing — the makers are stubs never called by the pure functions."""
-    r: Rule[Null] = Rule(left, [(list(rhs), Null, []) for rhs in rights])
+    r: Rule[Null] = Rule(left, [(list(rhs), Null, [], None) for rhs in rights])
     return r
 
 

--- a/tests/test_first_follow.py
+++ b/tests/test_first_follow.py
@@ -97,7 +97,7 @@ class RParen(Token):
 
 def make_rule(left: str, rights: list[list[Symbol]]) -> Rule[Null]:
     """Build a Rule for testing — the makers are stubs never called by the pure functions."""
-    r: Rule[Null] = Rule(left, [(list(rhs), Null, [], None) for rhs in rights])
+    r: Rule[Null] = Rule(left, [(list(rhs), Null, []) for rhs in rights])
     return r
 
 

--- a/tests/test_parser_safety_net.py
+++ b/tests/test_parser_safety_net.py
@@ -13,7 +13,10 @@ from plare.exception import ParsingError
 from plare.parser import Parser
 from plare.token import Token
 
-type GrammarRules[T] = tuple[list[type[Token] | str], type[T] | None, list[int]]
+type GrammarRules[T] = (
+    tuple[list[type[Token] | str], type[T] | None, list[int]]
+    | tuple[list[type[Token] | str], type[T] | None, list[int], type[Token]]
+)
 
 # ---------------------------------------------------------------------------
 # ε-productions

--- a/tests/test_prec_override.py
+++ b/tests/test_prec_override.py
@@ -1,0 +1,154 @@
+"""Tests for the 4-tuple prec_token grammar extension (yacc-style %prec).
+
+Verifies that a production's effective precedence can be overridden by
+supplying a prec_token as the 4th element of a grammar tuple, and that
+this override changes conflict resolution relative to the 3-tuple form.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from plare.parser import Parser
+from plare.token import Token
+
+# ---------------------------------------------------------------------------
+# Token definitions
+# ---------------------------------------------------------------------------
+
+
+class NUM(Token):
+    """Integer literal — stores the numeric value for AST construction."""
+
+    def __init__(self, value: str, *, lineno: int, offset: int) -> None:
+        self.value = int(value)
+        self.lineno = lineno
+        self.offset = offset
+
+
+class MINUS(Token):
+    """Binary/unary minus — precedence 1, left-associative."""
+
+    precedence = 1
+    associative = "left"
+
+
+class STAR(Token):
+    """Multiplication — precedence 2, left-associative."""
+
+    precedence = 2
+    associative = "left"
+
+
+class UMINUS(Token):
+    """Pseudo-token used exclusively as a prec_token override for unary minus.
+
+    Never emitted by any lexer.  Its higher precedence ensures that a unary-
+    minus production overrides the rightmost-terminal scan precedence.
+    """
+
+    precedence = 3
+    associative = "right"
+
+
+# ---------------------------------------------------------------------------
+# AST nodes
+# ---------------------------------------------------------------------------
+
+
+class Expr:
+    pass
+
+
+class Num(Expr):
+    def __init__(self, tok: NUM) -> None:
+        self.value = tok.value
+
+
+class Neg(Expr):
+    def __init__(self, operand: Expr) -> None:
+        self.operand = operand
+
+
+class Mul(Expr):
+    def __init__(self, left: Expr, right: Expr) -> None:
+        self.left = left
+        self.right = right
+
+
+# ---------------------------------------------------------------------------
+# Parser factories
+# ---------------------------------------------------------------------------
+
+
+def parser_with_prec_override() -> Parser[Expr]:
+    """Grammar with unary-minus production using UMINUS (prec=3) as prec_token."""
+    return Parser(
+        {
+            "expr": [
+                ([NUM], Num, [0]),
+                (["expr", STAR, "expr"], Mul, [0, 2]),
+                ([MINUS, "expr"], Neg, [1], UMINUS),
+            ]
+        }
+    )
+
+
+def parser_without_prec_override() -> Parser[Expr]:
+    """Same grammar but unary minus derives precedence from MINUS (prec=1)."""
+    return Parser(
+        {
+            "expr": [
+                ([NUM], Num, [0]),
+                (["expr", STAR, "expr"], Mul, [0, 2]),
+                ([MINUS, "expr"], Neg, [1]),
+            ]
+        }
+    )
+
+
+def token_stream() -> list[Token]:
+    """Token stream for the expression  -3 * 4."""
+    return [
+        MINUS("-", lineno=1, offset=0),
+        NUM("3", lineno=1, offset=1),
+        STAR("*", lineno=1, offset=2),
+        NUM("4", lineno=1, offset=3),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_prec_override_unary_minus_binds_tighter_than_mul() -> None:
+    """prec_token=UMINUS (prec=3) makes unary minus bind tighter than STAR (prec=2).
+
+    Input: -3 * 4
+
+    With override: the unary-minus production has effective prec=3, which
+    beats the STAR lookahead prec=2, so the parser reduces MINUS expr to
+    Neg(3) first, then multiplies: Mul(Neg(3), 4).
+
+    Without override: the unary-minus production inherits MINUS.prec=1, which
+    is lower than STAR.prec=2, so the parser shifts STAR and reduces the
+    multiplication first: Neg(Mul(3, 4)).
+    """
+    result_with = parser_with_prec_override().parse("expr", token_stream())
+    assert isinstance(
+        result_with, Mul
+    ), f"expected Mul, got {type(result_with).__name__}"
+    assert isinstance(
+        result_with.left, Neg
+    ), f"expected left child Neg, got {type(result_with.left).__name__}"
+    assert isinstance(result_with.left.operand, Num)
+    assert result_with.left.operand.value == 3
+    assert isinstance(result_with.right, Num)
+    assert result_with.right.value == 4
+
+    result_without = parser_without_prec_override().parse("expr", token_stream())
+    assert isinstance(
+        result_without, Neg
+    ), f"expected Neg, got {type(result_without).__name__}"
+    assert isinstance(result_without.operand, Mul)


### PR DESCRIPTION
## Summary

- `Parser.__init__` now accepts a 4-tuple `(rhs, action, args, prec_token)` grammar entry in addition to the existing 3-tuple form. The 4th element is a `Token` subclass whose `.precedence` value overrides the production's effective precedence, analogous to yacc's `%prec` directive.
- `Item` uses the override when given, falling back to the rightmost-terminal scan otherwise. `prec_override` is not stored as an attribute — it is consumed during construction and the result is kept in `Item.precedence`.
- `Rule.rights` stores `(rhs, maker, int | None)` tuples internally; the 3/4-tuple conversion lives entirely in `Parser.__init__`, since `Rule` is not part of the public API.

## Test plan

- [x] `pytest -q` passes (`30 passed, 2 xfailed`)
- [x] `tests/test_prec_override.py` — new test: parses `-3 * 4` under two grammars (with and without `prec_token=UMINUS`), asserts that the resulting ASTs differ (`Mul(Neg(3), 4)` vs `Neg(Mul(3, 4))`)
- [x] `python examples/calc/calc.py <input>` produces the same output as before (no regression)
- [x] `pyright` reports 0 errors; `black` and `isort` are clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)