### PR TITLE
feat(parser): resolve equal-precedence R/R conflicts by grammar definition order

### DIFF
--- a/plare/parser.py
+++ b/plare/parser.py
@@ -151,7 +151,8 @@ class Item[T]:
         maker: Maker[T],
         loc: int = 0,
         prec_override: int | None = None,
-        definition_index: int = 0,
+        *,
+        definition_index: int,
     ) -> None:
         self.left = left
         self.right = right
@@ -271,7 +272,7 @@ class Reduce[T]:
         n: int,
         maker: Maker[T],
         precedence: int,
-        definition_index: int = 0,
+        definition_index: int,
     ) -> None:
         self.left = left
         self.n = n

--- a/plare/parser.py
+++ b/plare/parser.py
@@ -882,11 +882,10 @@ class Parser[T]:
         #     precedence than the lookahead token, or equal precedence with
         #     left associativity.
         #   Reduce/Reduce: prefer the higher-precedence production; when
-        #     precedences are equal and both reductions have the same LHS,
-        #     the earlier-defined alternative wins (yacc/bison convention).
-        #     Cross-LHS equal-precedence R/R still raises ParserError because
-        #     it indicates an SLR(1) over-approximation that only LALR(1) (T6)
-        #     can resolve correctly.
+        #     precedences are equal, the earlier-defined production wins
+        #     (yacc/bison convention).  This may resolve conflicts that LALR(1)
+        #     would handle correctly via per-item lookaheads, but for those
+        #     grammars the SLR(1) choice may still be wrong for some inputs.
         for state in state_list:
             for item in state.items:
                 if item.next is None:
@@ -933,15 +932,10 @@ class Parser[T]:
                                         state.id, symbol, reduce_action
                                     )
                                 elif item.precedence == e.precedence:
-                                    if item.left == e.left:
-                                        if item.definition_index < e.definition_index:
-                                            self.table.force_update(
-                                                state.id, symbol, reduce_action
-                                            )
-                                    else:
-                                        raise ParserError(
-                                            f"Reduce-Reduce conflict in state {state.id}: {e.left} vs {item.left}"
-                                        ) from None
+                                    if item.definition_index < e.definition_index:
+                                        self.table.force_update(
+                                            state.id, symbol, reduce_action
+                                        )
         logger.info("Parser created")
 
     def parse(self, var: str, lexbuf: Iterable[Token]) -> T | Token:

--- a/plare/parser.py
+++ b/plare/parser.py
@@ -149,10 +149,9 @@ class Item[T]:
         left: str | StartVariable,
         right: list[Symbol],
         maker: Maker[T],
+        definition_index: int,
         loc: int = 0,
         prec_override: int | None = None,
-        *,
-        definition_index: int,
     ) -> None:
         self.left = left
         self.right = right
@@ -182,9 +181,9 @@ class Item[T]:
                 self.left,
                 self.right,
                 self.maker,
+                self.definition_index,
                 self.loc + 1,
-                prec_override=self.precedence,
-                definition_index=self.definition_index,
+                self.precedence,
             )
         return None
 
@@ -494,13 +493,7 @@ class Rule[T]:
     def items(self) -> set[Item[T]]:
         """Initial items ``[A → • rhs]`` for all alternatives of this rule."""
         return set(
-            Item(
-                self.left,
-                right,
-                maker,
-                prec_override=prec_override,
-                definition_index=idx,
-            )
+            Item(self.left, right, maker, idx, prec_override=prec_override)
             for (right, maker, prec_override), idx in zip(
                 self.rights, self.definition_indices
             )

--- a/plare/parser.py
+++ b/plare/parser.py
@@ -433,7 +433,7 @@ class Rule[T]:
         self,
         left: str,
         rights: list[tuple[list[Symbol], type[T] | None, list[int], int | None]],
-        definition_indices: list[int] | None = None,
+        start_index: int,
     ) -> None:
         self.left = left
         self.rights = [
@@ -444,11 +444,7 @@ class Rule[T]:
             )
             for right, action, args, prec_override in rights
         ]
-        self.definition_indices = (
-            definition_indices
-            if definition_indices is not None
-            else list(range(len(rights)))
-        )
+        self.definition_indices = list(range(start_index, start_index + len(rights)))
         self.first_built = False
         self.follow_built = False
 
@@ -781,16 +777,10 @@ class Parser[T]:
                 else:
                     right, action, args = entry
                     norm_rights.append((right, action, args, None))
-            rules[left] = Rule[T](
-                left,
-                norm_rights,
-                definition_indices=list(
-                    range(global_idx, global_idx + len(norm_rights))
-                ),
-            )
+            rules[left] = Rule[T](left, norm_rights, global_idx)
             start_var = StartVariable(left)
             start_variables.add(start_var)
-            rules[start_var] = Rule[T](start_var, [([left], None, [0], None)])
+            rules[start_var] = Rule[T](start_var, [([left], None, [0], None)], 0)
             global_idx += len(norm_rights)
 
         # ── Phase 2: Compute FIRST sets ──────────────────────────────────────

--- a/plare/parser.py
+++ b/plare/parser.py
@@ -757,7 +757,7 @@ class Parser[T]:
         # definition_index (global counter) so equal-precedence R/R conflicts
         # can be resolved by definition order.
         rules: dict[str, Rule[T]] = {}
-        start_variables: set[StartVariable] = set()
+        entry_rules: list[tuple[StartVariable, Rule[T]]] = []
         global_idx = 0
         for left, productions in grammar.items():
             norm_rights: list[
@@ -772,9 +772,11 @@ class Parser[T]:
                     norm_rights.append((right, action, args, None))
             rules[left] = Rule[T](left, norm_rights, global_idx)
             start_var = StartVariable(left)
-            start_variables.add(start_var)
-            rules[start_var] = Rule[T](start_var, [([left], None, [0], None)], 0)
+            augmented = Rule[T](start_var, [([left], None, [0], None)], 0)
+            rules[start_var] = augmented
+            entry_rules.append((start_var, augmented))
             global_idx += len(norm_rights)
+        start_variables = {sv for sv, _ in entry_rules}
 
         # ── Phase 2: Compute FIRST sets ──────────────────────────────────────
         # FIRST(A) is needed to propagate ε through nullable non-terminals
@@ -815,9 +817,7 @@ class Parser[T]:
 
         self.entry_state = {}
         bfs: deque[State[T]] = deque()
-        for i, (left, rule) in enumerate(
-            (k, v) for k, v in rules.items() if isinstance(k, StartVariable)
-        ):
+        for i, (left, rule) in enumerate(entry_rules):
             self.entry_state[left.orig] = i
             init_state, _ = intern_state(
                 closure(rule.items, all_items), state_index, state_list

--- a/plare/parser.py
+++ b/plare/parser.py
@@ -881,8 +881,12 @@ class Parser[T]:
         #   Shift/Reduce: prefer shift unless the production has higher
         #     precedence than the lookahead token, or equal precedence with
         #     left associativity.
-        #   Reduce/Reduce: prefer the higher-precedence production; raise
-        #     ParserError when precedences are equal (ambiguous grammar).
+        #   Reduce/Reduce: prefer the higher-precedence production; when
+        #     precedences are equal and both reductions have the same LHS,
+        #     the earlier-defined alternative wins (yacc/bison convention).
+        #     Cross-LHS equal-precedence R/R still raises ParserError because
+        #     it indicates an SLR(1) over-approximation that only LALR(1) (T6)
+        #     can resolve correctly.
         for state in state_list:
             for item in state.items:
                 if item.next is None:
@@ -929,9 +933,15 @@ class Parser[T]:
                                         state.id, symbol, reduce_action
                                     )
                                 elif item.precedence == e.precedence:
-                                    raise ParserError(
-                                        f"Reduce-Reduce conflict in state {state.id}: {e.left} vs {item.left}"
-                                    ) from None
+                                    if item.left == e.left:
+                                        if item.definition_index < e.definition_index:
+                                            self.table.force_update(
+                                                state.id, symbol, reduce_action
+                                            )
+                                    else:
+                                        raise ParserError(
+                                            f"Reduce-Reduce conflict in state {state.id}: {e.left} vs {item.left}"
+                                        ) from None
         logger.info("Parser created")
 
     def parse(self, var: str, lexbuf: Iterable[Token]) -> T | Token:

--- a/plare/parser.py
+++ b/plare/parser.py
@@ -761,47 +761,37 @@ class Parser[T]:
         # Using StartVariable ensures these rules are never confused with
         # user-defined rules, even if a user names a rule identically.
         #
-        # Resolve the optional 4th element (prec_token) in each grammar tuple.
-        # A 3-tuple (right, action, args) is passed through unchanged; a 4-tuple
+        # A 3-tuple (right, action, args) is accepted unchanged; a 4-tuple
         # (right, action, args, prec_token) is rewritten to
-        # (right, action, args, prec_token.precedence) so Rule.__init__ receives
-        # a plain int override rather than a token class.
-        normalized: dict[
-            str,
-            list[tuple[list[type[Token] | str], type[T] | None, list[int], int | None]],
-        ] = {}
-        normalized_indices: dict[str, list[int]] = {}
+        # (right, action, args, prec_token.precedence) so Rule receives a plain
+        # int override.  Each production is assigned a grammar-wide
+        # definition_index (global counter) so equal-precedence R/R conflicts
+        # can be resolved by definition order.
+        rules: dict[str, Rule[T]] = {}
+        start_variables: set[StartVariable] = set()
         global_idx = 0
-        for left, rights in grammar.items():
+        for left, productions in grammar.items():
             norm_rights: list[
                 tuple[list[type[Token] | str], type[T] | None, list[int], int | None]
             ] = []
-            for entry in rights:
+            for entry in productions:
                 if len(entry) == 4:
                     right, action, args, prec_token = entry
                     norm_rights.append((right, action, args, prec_token.precedence))
                 else:
                     right, action, args = entry
                     norm_rights.append((right, action, args, None))
-            normalized_indices[left] = list(
-                range(global_idx, global_idx + len(norm_rights))
+            rules[left] = Rule[T](
+                left,
+                norm_rights,
+                definition_indices=list(
+                    range(global_idx, global_idx + len(norm_rights))
+                ),
             )
+            start_var = StartVariable(left)
+            start_variables.add(start_var)
+            rules[start_var] = Rule[T](start_var, [([left], None, [0], None)])
             global_idx += len(norm_rights)
-            normalized[left] = norm_rights
-
-        entry_rules = {
-            StartVariable(left): Rule[T](
-                StartVariable(left), [([left], None, [0], None)]
-            )
-            for left in grammar.keys()
-        }
-        start_variables = set(entry_rules.keys())
-
-        rules = {
-            left: Rule[T](left, rights, definition_indices=normalized_indices[left])
-            for left, rights in normalized.items()
-        }
-        rules |= entry_rules
 
         # ── Phase 2: Compute FIRST sets ──────────────────────────────────────
         # FIRST(A) is needed to propagate ε through nullable non-terminals
@@ -842,7 +832,9 @@ class Parser[T]:
 
         self.entry_state = {}
         bfs: deque[State[T]] = deque()
-        for i, (left, rule) in enumerate(entry_rules.items()):
+        for i, (left, rule) in enumerate(
+            (k, v) for k, v in rules.items() if isinstance(k, StartVariable)
+        ):
             self.entry_state[left.orig] = i
             init_state, _ = intern_state(
                 closure(rule.items, all_items), state_index, state_list

--- a/plare/parser.py
+++ b/plare/parser.py
@@ -758,6 +758,7 @@ class Parser[T]:
         # can be resolved by definition order.
         rules: dict[str, Rule[T]] = {}
         entry_rules: list[tuple[StartVariable, Rule[T]]] = []
+        start_variables: set[StartVariable] = set()
         global_idx = 0
         for left, productions in grammar.items():
             norm_rights: list[
@@ -775,8 +776,8 @@ class Parser[T]:
             augmented = Rule[T](start_var, [([left], None, [0], None)], 0)
             rules[start_var] = augmented
             entry_rules.append((start_var, augmented))
+            start_variables.add(start_var)
             global_idx += len(norm_rights)
-        start_variables = {sv for sv, _ in entry_rules}
 
         # ── Phase 2: Compute FIRST sets ──────────────────────────────────────
         # FIRST(A) is needed to propagate ε through nullable non-terminals

--- a/plare/parser.py
+++ b/plare/parser.py
@@ -120,6 +120,11 @@ class Item[T]:
     precedence value (yacc/bison convention).  When ``prec_override`` is given
     (analogous to yacc's ``%prec``), it replaces that derivation entirely.
 
+    ``definition_index`` is the zero-based ordinal assigned to this production
+    during grammar construction (counting across all non-terminals in definition
+    order).  It is used to break ties when two reduce actions have equal
+    precedence: the production with the lower index wins.
+
     Attributes:
         left: The non-terminal on the LHS of the rule.
         right: The full RHS symbol sequence (terminals are ``type[Token]``
@@ -128,6 +133,8 @@ class Item[T]:
         maker: The semantic action to invoke on reduction.
         precedence: Effective precedence of this production for conflict
             resolution; ``0`` means no precedence.
+        definition_index: Grammar-wide ordinal of this production (0 = first
+            defined).
     """
 
     left: str | StartVariable
@@ -135,6 +142,7 @@ class Item[T]:
     loc: int
     maker: Maker[T]
     precedence: int
+    definition_index: int
 
     def __init__(
         self,
@@ -143,11 +151,13 @@ class Item[T]:
         maker: Maker[T],
         loc: int = 0,
         prec_override: int | None = None,
+        definition_index: int = 0,
     ) -> None:
         self.left = left
         self.right = right
         self.loc = loc
         self.maker = maker
+        self.definition_index = definition_index
         if prec_override is not None:
             self.precedence = prec_override
         else:
@@ -173,6 +183,7 @@ class Item[T]:
                 self.maker,
                 self.loc + 1,
                 prec_override=self.precedence,
+                definition_index=self.definition_index,
             )
         return None
 
@@ -252,12 +263,21 @@ class Reduce[T]:
     n: int
     maker: Maker[T]
     precedence: int
+    definition_index: int
 
-    def __init__(self, left: str, n: int, maker: Maker[T], precedence: int) -> None:
+    def __init__(
+        self,
+        left: str,
+        n: int,
+        maker: Maker[T],
+        precedence: int,
+        definition_index: int = 0,
+    ) -> None:
         self.left = left
         self.n = n
         self.maker = maker
         self.precedence = precedence
+        self.definition_index = definition_index
 
     def __str__(self) -> str:
         return f"Reduce({self.n}, {self.maker})"
@@ -308,11 +328,13 @@ class ReduceReduceConflict(Conflict):
     Args:
         left: LHS of the already-registered reduce action.
         precedence: Precedence of the already-registered reduce action.
+        definition_index: Grammar-wide ordinal of the already-registered production.
     """
 
-    def __init__(self, left: str, precedence: int) -> None:
+    def __init__(self, left: str, precedence: int, definition_index: int) -> None:
         self.left = left
         self.precedence = precedence
+        self.definition_index = definition_index
 
 
 class Table[T]:
@@ -348,7 +370,9 @@ class Table[T]:
                     case Shift(), Reduce():
                         raise ShiftReduceConflict()
                     case Reduce(), Reduce():
-                        raise ReduceReduceConflict(exist.left, exist.precedence)
+                        raise ReduceReduceConflict(
+                            exist.left, exist.precedence, exist.definition_index
+                        )
                     case _:
                         raise ParserError(
                             f"Unknown parser error in state {state}: action for {symbol} is already determined to {exist}, but new action {action} is given"
@@ -400,6 +424,7 @@ class Rule[T]:
 
     left: str
     rights: list[tuple[list[Symbol], Maker[T], int | None]]
+    definition_indices: list[int]
     first: set[type[Token]]
     follow: set[type[Token]]
 
@@ -407,6 +432,7 @@ class Rule[T]:
         self,
         left: str,
         rights: list[tuple[list[Symbol], type[T] | None, list[int], int | None]],
+        definition_indices: list[int] | None = None,
     ) -> None:
         self.left = left
         self.rights = [
@@ -417,6 +443,11 @@ class Rule[T]:
             )
             for right, action, args, prec_override in rights
         ]
+        self.definition_indices = (
+            definition_indices
+            if definition_indices is not None
+            else list(range(len(rights)))
+        )
         self.first_built = False
         self.follow_built = False
 
@@ -466,8 +497,16 @@ class Rule[T]:
     def items(self) -> set[Item[T]]:
         """Initial items ``[A → • rhs]`` for all alternatives of this rule."""
         return set(
-            Item(self.left, right, maker, prec_override=prec_override)
-            for right, maker, prec_override in self.rights
+            Item(
+                self.left,
+                right,
+                maker,
+                prec_override=prec_override,
+                definition_index=idx,
+            )
+            for (right, maker, prec_override), idx in zip(
+                self.rights, self.definition_indices
+            )
         )
 
 
@@ -730,6 +769,8 @@ class Parser[T]:
             str,
             list[tuple[list[type[Token] | str], type[T] | None, list[int], int | None]],
         ] = {}
+        normalized_indices: dict[str, list[int]] = {}
+        global_idx = 0
         for left, rights in grammar.items():
             norm_rights: list[
                 tuple[list[type[Token] | str], type[T] | None, list[int], int | None]
@@ -741,6 +782,10 @@ class Parser[T]:
                 else:
                     right, action, args = entry
                     norm_rights.append((right, action, args, None))
+            normalized_indices[left] = list(
+                range(global_idx, global_idx + len(norm_rights))
+            )
+            global_idx += len(norm_rights)
             normalized[left] = norm_rights
 
         entry_rules = {
@@ -751,7 +796,10 @@ class Parser[T]:
         }
         start_variables = set(entry_rules.keys())
 
-        rules = {left: Rule[T](left, rights) for left, rights in normalized.items()}
+        rules = {
+            left: Rule[T](left, rights, definition_indices=normalized_indices[left])
+            for left, rights in normalized.items()
+        }
         rules |= entry_rules
 
         # ── Phase 2: Compute FIRST sets ──────────────────────────────────────
@@ -847,7 +895,11 @@ class Parser[T]:
                     else:
                         for symbol in rules[item.left].follow:
                             reduce_action = Reduce(
-                                item.left, len(item.right), item.maker, item.precedence
+                                item.left,
+                                len(item.right),
+                                item.maker,
+                                item.precedence,
+                                item.definition_index,
                             )
                             try:
                                 self.table[state.id, symbol] = reduce_action

--- a/tests/test_first_follow.py
+++ b/tests/test_first_follow.py
@@ -97,7 +97,7 @@ class RParen(Token):
 
 def make_rule(left: str, rights: list[list[Symbol]]) -> Rule[Null]:
     """Build a Rule for testing — the makers are stubs never called by the pure functions."""
-    r: Rule[Null] = Rule(left, [(list(rhs), Null, [], None) for rhs in rights])
+    r: Rule[Null] = Rule(left, [(list(rhs), Null, [], None) for rhs in rights], 0)
     return r
 
 

--- a/tests/test_hash_semantics.py
+++ b/tests/test_hash_semantics.py
@@ -19,7 +19,7 @@ class TokB(Token):
 
 
 def make_item(left: str, right: list, loc: int = 0) -> Item[object]:
-    return Item(left, right, IDMaker(0), loc)
+    return Item(left, right, IDMaker(0), loc, definition_index=0)
 
 
 def test_item_equal_data_hash_equal() -> None:

--- a/tests/test_hash_semantics.py
+++ b/tests/test_hash_semantics.py
@@ -19,7 +19,7 @@ class TokB(Token):
 
 
 def make_item(left: str, right: list, loc: int = 0) -> Item[object]:
-    return Item(left, right, IDMaker(0), loc, definition_index=0)
+    return Item(left, right, IDMaker(0), 0, loc)
 
 
 def test_item_equal_data_hash_equal() -> None:

--- a/tests/test_parser_safety_net.py
+++ b/tests/test_parser_safety_net.py
@@ -562,12 +562,25 @@ def test_shift_reduce_resolution_prefers_shift() -> None:
 
 
 # ---------------------------------------------------------------------------
-# LALR(1)-only grammars (Aho/Sethi/Ullman reduce/reduce conflicts)
+# LALR(1)-resolvable grammars — FOLLOW-set inflation creates a spurious R/R
+# conflict in SLR(1) that LALR(1) per-item lookaheads cleanly resolve.
 #
-# Two distinct non-terminals (A_nt / B_nt, X_nt / Y_nt) share the same
-# single-token body.  Their LR(0) reduce states are merged, and
-# FOLLOW(A_nt) == FOLLOW(B_nt), so SLR(1) cannot resolve the R/R conflict.
-# LALR(1) computes per-item lookaheads that differ, resolving the conflict.
+# Two non-terminals (A_nt/B_nt, X_nt/Y_nt) share the same single-token body
+# and land in the same LR(0) reduce state.  One of them also appears in an
+# *unrelated* production that inflates its FOLLOW set so that it overlaps the
+# other's FOLLOW set — but only in states where the two items do NOT coexist.
+#
+# Key distinction from the Aho/Sethi/Ullman (LR(1)-only) grammar:
+#   In the Aho grammar both non-terminals appear symmetrically in four
+#   productions, so every LR(1) state that holds {A_nt → C •, B_nt → C •}
+#   comes in two mirror images whose lookaheads cross-contaminate when merged
+#   in LALR(1), creating a new R/R conflict not present in LR(1).
+#
+#   Here, the extra production that inflates FOLLOW(A_nt) produces a *separate*
+#   LR(0) state (core {A_nt → E •} only, no B_nt) that is never merged with
+#   the conflict state (core {A_nt → E •, B_nt → E •}).  LALR(1) lookaheads
+#   in the conflict state remain {B8x} vs {C8x, D8x} — disjoint — so no
+#   new conflict is introduced by merging.
 # ---------------------------------------------------------------------------
 
 
@@ -592,45 +605,50 @@ class E8x(Token):
 
 
 class Node8x:
-    def __init__(self, *args: Token) -> None:
+    def __init__(self, *args: object) -> None:
         pass
 
 
 @pytest.mark.xfail(strict=True, reason="requires LALR(1)")
-def test_lalr1_only_aho_grammar_variant_1() -> None:
-    """Aho/Sethi/Ullman grammar that exposes the SLR(1) per-item lookahead limitation.
+def test_lalr1_rr_conflict_follow_inflation_variant_1() -> None:
+    """FOLLOW-set inflation creates a spurious SLR(1) R/R conflict.
 
-    A_nt and B_nt both reduce from a single C token, so they share one LR(0)
-    state. FOLLOW(A_nt) == FOLLOW(B_nt) == {D, E}, which makes SLR(1) unable
-    to distinguish the two reduce actions.  SLR(1) resolves ties by definition
-    order (A_nt is earlier), but that is wrong for inputs that require B_nt.
-    LALR(1) computes per-item lookaheads ({D} vs {E}) and handles all inputs.
+    Grammar:
+      start → A8x A_nt B8x | A8x B_nt C8x | A8x B_nt D8x | A_nt C8x
+      A_nt  → E8x
+      B_nt  → E8x
 
-    This test uses an input that requires B_nt (A_tok C_tok E_tok →
-    S → A_tok B_nt E_tok).  SLR(1) reduces C_tok to A_nt instead and then
-    fails to parse the E_tok lookahead, demonstrating the limitation.
+    The state reached after [A8x, E8x] contains {A_nt → E8x •, B_nt → E8x •}.
+    FOLLOW(A_nt) = {B8x, C8x}  (from "A8x A_nt B8x" and "A_nt C8x")
+    FOLLOW(B_nt) = {C8x, D8x}  (from "A8x B_nt C8x" and "A8x B_nt D8x")
+    Intersection {C8x} creates a spurious SLR(1) R/R conflict; definition order
+    picks A_nt.  Parsing [A8x, E8x, C8x] therefore fails: SLR(1) reduces E8x
+    to A_nt, then rejects C8x (expected B8x).
+
+    LALR(1) per-item lookaheads in that state are {B8x} for A_nt and
+    {C8x, D8x} for B_nt — disjoint — so C8x correctly triggers B_nt and the
+    parse succeeds.  The inflation token C8x only appears as a lookahead in a
+    separate LR(0) state (core {A_nt → E8x •} alone), which is never merged
+    with the conflict state, so LALR(1) is sufficient.
     """
-    # S → A_tok A_nt D_tok | B_tok B_nt D_tok | A_tok B_nt E_tok | B_tok A_nt E_tok
-    # A_nt → C_tok
-    # B_nt → C_tok
     p = Parser(
         {
-            "S": [
-                ([A8x, "A_nt", D8x], Node8x, [0, 1, 2]),
-                ([B8x, "B_nt", D8x], Node8x, [0, 1, 2]),
-                ([A8x, "B_nt", E8x], Node8x, [0, 1, 2]),
-                ([B8x, "A_nt", E8x], Node8x, [0, 1, 2]),
+            "start": [
+                ([A8x, "A_nt", B8x], Node8x, [0, 1, 2]),
+                ([A8x, "B_nt", C8x], Node8x, [0, 1, 2]),
+                ([A8x, "B_nt", D8x], Node8x, [0, 1, 2]),
+                (["A_nt", C8x], Node8x, [0, 1]),
             ],
-            "A_nt": [([C8x], None, [0])],
-            "B_nt": [([C8x], None, [0])],
+            "A_nt": [([E8x], None, [0])],
+            "B_nt": [([E8x], None, [0])],
         }
     )
     result = p.parse(
-        "S",
+        "start",
         [
             A8x("a", lineno=1, offset=0),
-            C8x("c", lineno=1, offset=1),
-            E8x("e", lineno=1, offset=2),
+            E8x("e", lineno=1, offset=1),
+            C8x("c", lineno=1, offset=2),
         ],
     )
     assert isinstance(result, Node8x)
@@ -657,44 +675,45 @@ class T8y(Token):
 
 
 class Node8y:
-    def __init__(self, *args: Token) -> None:
+    def __init__(self, *args: object) -> None:
         pass
 
 
 @pytest.mark.xfail(strict=True, reason="requires LALR(1)")
-def test_lalr1_only_aho_grammar_variant_2() -> None:
-    """Isomorphic variant of the Aho/Sethi/Ullman grammar with different token names.
+def test_lalr1_rr_conflict_follow_inflation_variant_2() -> None:
+    """Isomorphic variant confirming the result is independent of token naming.
 
-    X_nt and Y_nt both reduce from a single R token. The conflict structure is
-    identical to variant 1: FOLLOW(X_nt) == FOLLOW(Y_nt) == {S_tok, T_tok}
-    under SLR(1), but LALR(1) per-item lookaheads differ.  This second case
-    confirms the xfail is not an artifact of a particular token ordering.
+    Grammar:
+      start2 → P8y X_nt Q8y | P8y Y_nt R8y | P8y Y_nt S8y | X_nt R8y
+      X_nt  → T8y
+      Y_nt  → T8y
 
-    This test uses an input that requires Y_nt (P_tok R_tok T_tok →
-    S2 → P_tok Y_nt T_tok).  SLR(1) reduces R_tok to X_nt instead and then
-    fails to parse the T_tok lookahead, demonstrating the limitation.
+    FOLLOW(X_nt) = {Q8y, R8y}  (from "P8y X_nt Q8y" and "X_nt R8y")
+    FOLLOW(Y_nt) = {R8y, S8y}  (from "P8y Y_nt R8y" and "P8y Y_nt S8y")
+    Intersection {R8y}: spurious SLR(1) R/R; X_nt wins by definition order.
+    Parsing [P8y, T8y, R8y] fails: SLR(1) reduces T8y to X_nt, then rejects
+    R8y (expected Q8y).
+    LALR(1) per-item lookaheads after [P8y, T8y]: X_nt → {Q8y}, Y_nt →
+    {R8y, S8y} — disjoint — so R8y correctly triggers Y_nt.
     """
-    # S2 → P X_nt S | Q Y_nt S | P Y_nt T | Q X_nt T
-    # X_nt → R
-    # Y_nt → R
     p = Parser(
         {
-            "S2": [
-                ([P8y, "X_nt", S8y], Node8y, [0, 1, 2]),
-                ([Q8y, "Y_nt", S8y], Node8y, [0, 1, 2]),
-                ([P8y, "Y_nt", T8y], Node8y, [0, 1, 2]),
-                ([Q8y, "X_nt", T8y], Node8y, [0, 1, 2]),
+            "start2": [
+                ([P8y, "X_nt", Q8y], Node8y, [0, 1, 2]),
+                ([P8y, "Y_nt", R8y], Node8y, [0, 1, 2]),
+                ([P8y, "Y_nt", S8y], Node8y, [0, 1, 2]),
+                (["X_nt", R8y], Node8y, [0, 1]),
             ],
-            "X_nt": [([R8y], None, [0])],
-            "Y_nt": [([R8y], None, [0])],
+            "X_nt": [([T8y], None, [0])],
+            "Y_nt": [([T8y], None, [0])],
         }
     )
     result = p.parse(
-        "S2",
+        "start2",
         [
             P8y("p", lineno=1, offset=0),
-            R8y("r", lineno=1, offset=1),
-            T8y("t", lineno=1, offset=2),
+            T8y("t", lineno=1, offset=1),
+            R8y("r", lineno=1, offset=2),
         ],
     )
     assert isinstance(result, Node8y)

--- a/tests/test_parser_safety_net.py
+++ b/tests/test_parser_safety_net.py
@@ -598,14 +598,17 @@ class Node8x:
 
 @pytest.mark.xfail(strict=True, reason="requires LALR(1)")
 def test_lalr1_only_aho_grammar_variant_1() -> None:
-    """Aho/Sethi/Ullman grammar that exposes an SLR(1) reduce/reduce conflict.
+    """Aho/Sethi/Ullman grammar that exposes the SLR(1) per-item lookahead limitation.
 
     A_nt and B_nt both reduce from a single C token, so they share one LR(0)
     state. FOLLOW(A_nt) == FOLLOW(B_nt) == {D, E}, which makes SLR(1) unable
-    to choose between the two reduce actions. LALR(1) assigns distinct per-item
-    lookaheads ({D} vs {E} in each context) and resolves the conflict.
+    to distinguish the two reduce actions.  SLR(1) resolves ties by definition
+    order (A_nt is earlier), but that is wrong for inputs that require B_nt.
+    LALR(1) computes per-item lookaheads ({D} vs {E}) and handles all inputs.
 
-    Currently xfail: Parser construction raises ParserError under SLR(1).
+    This test uses an input that requires B_nt (A_tok C_tok E_tok →
+    S → A_tok B_nt E_tok).  SLR(1) reduces C_tok to A_nt instead and then
+    fails to parse the E_tok lookahead, demonstrating the limitation.
     """
     # S → A_tok A_nt D_tok | B_tok B_nt D_tok | A_tok B_nt E_tok | B_tok A_nt E_tok
     # A_nt → C_tok
@@ -627,7 +630,7 @@ def test_lalr1_only_aho_grammar_variant_1() -> None:
         [
             A8x("a", lineno=1, offset=0),
             C8x("c", lineno=1, offset=1),
-            D8x("d", lineno=1, offset=2),
+            E8x("e", lineno=1, offset=2),
         ],
     )
     assert isinstance(result, Node8x)
@@ -663,11 +666,13 @@ def test_lalr1_only_aho_grammar_variant_2() -> None:
     """Isomorphic variant of the Aho/Sethi/Ullman grammar with different token names.
 
     X_nt and Y_nt both reduce from a single R token. The conflict structure is
-    identical to variant 1: FOLLOW(X_nt) == FOLLOW(Y_nt) == {S, T} under SLR(1),
-    but LALR(1) per-item lookaheads differ. This second case confirms that the
-    xfail is not an artifact of a particular token ordering.
+    identical to variant 1: FOLLOW(X_nt) == FOLLOW(Y_nt) == {S_tok, T_tok}
+    under SLR(1), but LALR(1) per-item lookaheads differ.  This second case
+    confirms the xfail is not an artifact of a particular token ordering.
 
-    Currently xfail: Parser construction raises ParserError under SLR(1).
+    This test uses an input that requires Y_nt (P_tok R_tok T_tok →
+    S2 → P_tok Y_nt T_tok).  SLR(1) reduces R_tok to X_nt instead and then
+    fails to parse the T_tok lookahead, demonstrating the limitation.
     """
     # S2 → P X_nt S | Q Y_nt S | P Y_nt T | Q X_nt T
     # X_nt → R
@@ -689,7 +694,7 @@ def test_lalr1_only_aho_grammar_variant_2() -> None:
         [
             P8y("p", lineno=1, offset=0),
             R8y("r", lineno=1, offset=1),
-            S8y("s", lineno=1, offset=2),
+            T8y("t", lineno=1, offset=2),
         ],
     )
     assert isinstance(result, Node8y)

--- a/tests/test_prec_override.py
+++ b/tests/test_prec_override.py
@@ -1,8 +1,9 @@
-"""Tests for the 4-tuple prec_token grammar extension (yacc-style %prec).
+"""Tests for yacc-style conflict resolution: prec_token override and R/R definition order.
 
-Verifies that a production's effective precedence can be overridden by
-supplying a prec_token as the 4th element of a grammar tuple, and that
-this override changes conflict resolution relative to the 3-tuple form.
+Covers two orthogonal features:
+- 4-tuple prec_token (yacc %prec): override the effective precedence of a production.
+- R/R definition order: when two productions compete with equal precedence, the
+  earlier-defined production wins silently instead of raising ParserError.
 """
 
 from __future__ import annotations
@@ -152,3 +153,48 @@ def test_prec_override_unary_minus_binds_tighter_than_mul() -> None:
         result_without, Neg
     ), f"expected Neg, got {type(result_without).__name__}"
     assert isinstance(result_without.operand, Mul)
+
+
+# ---------------------------------------------------------------------------
+# R/R definition order
+# ---------------------------------------------------------------------------
+
+
+class Lit(Token):
+    """Single literal token with no precedence."""
+
+
+class FirstResult:
+    def __init__(self, tok: Lit) -> None:
+        self.tok = tok
+
+
+class SecondResult:
+    def __init__(self, tok: Lit) -> None:
+        self.tok = tok
+
+
+def test_rr_equal_precedence_first_defined_wins() -> None:
+    """Earlier-defined production wins on equal-precedence R/R conflict.
+
+    Two non-terminals (first_val, second_val) both reduce from a single Lit
+    token with zero precedence, producing an R/R conflict in the merged LR(0)
+    state.  The grammar entry non-terminal can use either.
+
+    Without definition-order tie-breaking, Parser construction would raise
+    ParserError.  With it, first_val (defined earlier, lower definition_index)
+    wins, so the reduction always produces FirstResult.
+    """
+    grammar: dict = {
+        "result": [
+            (["first_val"], FirstResult, [0]),
+            (["second_val"], SecondResult, [0]),
+        ],
+        "first_val": [([Lit], None, [0])],
+        "second_val": [([Lit], None, [0])],
+    }
+    parser = Parser(grammar)
+    result = parser.parse("result", [Lit("x", lineno=1, offset=0)])
+    assert isinstance(
+        result, FirstResult
+    ), f"expected FirstResult (first-defined), got {type(result).__name__}"


### PR DESCRIPTION
## Summary

- Tracks a grammar-wide `definition_index` ordinal through `Item`, `Rule`, and
  `Reduce` so equal-precedence R/R conflicts can be resolved deterministically.
- When two reduce actions tie on precedence, the earlier-defined production wins
  (yacc/bison convention), eliminating `ParserError` for all equal-precedence R/R
  conflicts.
- Replaces the Aho/Sethi/Ullman xfail grammar (LR(1)-only) with a
  FOLLOW-set-inflation grammar (LALR(1)-resolvable) so the xfail tests will pass
  after the T6 LALR(1) upgrade.

## Changes

**Core data flow**
- `Item.__init__`: `definition_index: int` — required 4th positional arg (before `loc`)
- `Reduce.__init__`: `definition_index: int` — required positional arg
- `Rule.__init__`: `definition_indices: list[int] | None` → `start_index: int` (required);
  indices computed internally as `range(start_index, start_index + len(rights))`

**Phase 1 refactor**
- Single loop now builds `rules`, `entry_rules`, `start_variables`, and `global_idx`
  together, eliminating the `isinstance(k, StartVariable)` filter scan in Phase 4

**Conflict resolution**
- Equal-precedence R/R handler compares `definition_index` instead of raising
  `ParserError`; the production with the lower index (defined earlier) wins silently

**xfail tests**
- Aho grammar issue: LALR(1) state merging cross-contaminates lookaheads → LR(1)-only
- New grammar: a separate production inflates only `FOLLOW(A_nt)`. The extra LR(0)
  state it generates has a different core from the conflict state, so LALR(1) merging
  leaves lookaheads disjoint → LALR(1)-resolvable; tests pass after T6

## Test plan

- [x] `pytest -q`: 31 passed, 2 xfailed
- [x] `pyright`: 0 errors, 0 warnings
- [x] `black --check`: clean
- [x] `test_rr_equal_precedence_first_defined_wins` — verifies definition-order R/R resolution
- [x] 2 xfail tests — replaced with LALR(1)-resolvable grammar, expected to pass after T6