### PR TITLE
feat(types): enable pyright strict mode

### DIFF
--- a/plare/parser.py
+++ b/plare/parser.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 from collections import deque
 from itertools import chain
-from typing import Iterable, Protocol
+from typing import Iterable, Protocol, TypeGuard
 
 from plare.exception import ParserError, ParsingError
 from plare.token import Token
@@ -241,18 +241,18 @@ class State[T]:
         self.items = items
         self.lookaheads = {}
 
-    @property
-    def _items_hash(self) -> int:
+    def __hash__(self) -> int:
         return hash(frozenset(self.items))
 
-    def __hash__(self) -> int:
-        return self._items_hash
-
     def __eq__(self, other: object) -> bool:
-        return isinstance(other, State) and self._items_hash == other._items_hash
+        return _is_state(other) and self.items == other.items
 
     def __str__(self) -> str:
         return "\n".join(map(str, self.items))
+
+
+def _is_state(obj: object) -> TypeGuard[State[object]]:
+    return isinstance(obj, State)
 
 
 class Shift:

--- a/plare/parser.py
+++ b/plare/parser.py
@@ -244,8 +244,7 @@ class State[T]:
     def __hash__(self) -> int:
         return hash(frozenset(self.items))
 
-    @classmethod
-    def is_instance(cls, obj: object) -> TypeGuard[State[T]]:
+    def is_instance(self, obj: object) -> TypeGuard[State[T]]:
         return isinstance(obj, State)
 
     def __eq__(self, other: object) -> bool:

--- a/plare/parser.py
+++ b/plare/parser.py
@@ -245,13 +245,13 @@ class State[T]:
         return hash(frozenset(self.items))
 
     def __eq__(self, other: object) -> bool:
-        return _is_state(other) and self.items == other.items
+        return is_state(other) and self.items == other.items
 
     def __str__(self) -> str:
         return "\n".join(map(str, self.items))
 
 
-def _is_state(obj: object) -> TypeGuard[State[object]]:
+def is_state(obj: object) -> TypeGuard[State[object]]:
     return isinstance(obj, State)
 
 

--- a/plare/parser.py
+++ b/plare/parser.py
@@ -244,15 +244,15 @@ class State[T]:
     def __hash__(self) -> int:
         return hash(frozenset(self.items))
 
+    @classmethod
+    def is_instance(cls, obj: object) -> TypeGuard[State[T]]:
+        return isinstance(obj, State)
+
     def __eq__(self, other: object) -> bool:
-        return is_state(other) and self.items == other.items
+        return self.is_instance(other) and self.items == other.items
 
     def __str__(self) -> str:
         return "\n".join(map(str, self.items))
-
-
-def is_state(obj: object) -> TypeGuard[State[object]]:
-    return isinstance(obj, State)
 
 
 class Shift:

--- a/plare/parser.py
+++ b/plare/parser.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 from collections import deque
 from itertools import chain
-from typing import Any, Iterable, Protocol
+from typing import Iterable, Protocol
 
 from plare.exception import ParserError, ParsingError
 from plare.token import Token
@@ -106,10 +106,10 @@ class StartVariable(str):
     def __hash__(self) -> int:
         return super().__hash__()
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: object) -> bool:
         return isinstance(other, StartVariable) and super().__eq__(other)
 
-    def __ne__(self, other: Any) -> bool:
+    def __ne__(self, other: object) -> bool:
         return not isinstance(other, StartVariable) or super().__ne__(other)
 
 
@@ -211,7 +211,7 @@ class Item[T]:
     def __hash__(self) -> int:
         return hash((self.left, tuple(self.right), self.loc))
 
-    def __eq__(self, value: Any) -> bool:
+    def __eq__(self, value: object) -> bool:
         return (
             isinstance(value, Item)
             and self.left == value.left
@@ -241,11 +241,15 @@ class State[T]:
         self.items = items
         self.lookaheads = {}
 
-    def __hash__(self) -> int:
+    @property
+    def _items_hash(self) -> int:
         return hash(frozenset(self.items))
 
-    def __eq__(self, other: State[T] | Any) -> bool:
-        return isinstance(other, State) and self.items == other.items
+    def __hash__(self) -> int:
+        return self._items_hash
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, State) and self._items_hash == other._items_hash
 
     def __str__(self) -> str:
         return "\n".join(map(str, self.items))
@@ -494,7 +498,7 @@ class Rule[T]:
     def __hash__(self) -> int:
         return hash(self.left)
 
-    def __eq__(self, value: Any) -> bool:
+    def __eq__(self, value: object) -> bool:
         return isinstance(value, Rule) and self.left == value.left
 
     def __repr__(self) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,5 +53,8 @@ markers = [
     "slow: marks tests as slow-running (deselect with '-m \"not slow\"')",
 ]
 
+[tool.pyright]
+typeCheckingMode = "strict"
+
 [tool.isort]
 profile = "black"

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -19,8 +19,8 @@ from plare.token import Token
 type Grammar = dict[
     str,
     list[
-        tuple[list[type[Token] | str], type | None, list[int]]
-        | tuple[list[type[Token] | str], type | None, list[int], type[Token]]
+        tuple[list[type[Token] | str], type[object] | None, list[int]]
+        | tuple[list[type[Token] | str], type[object] | None, list[int], type[Token]]
     ],
 ]
 

--- a/tests/test_hash_semantics.py
+++ b/tests/test_hash_semantics.py
@@ -18,7 +18,7 @@ class TokB(Token):
         self.offset = offset
 
 
-def make_item(left: str, right: list, loc: int = 0) -> Item[object]:
+def make_item(left: str, right: list[type[Token] | str], loc: int = 0) -> Item[object]:
     return Item(left, right, IDMaker(0), 0, loc)
 
 

--- a/tests/test_prec_override.py
+++ b/tests/test_prec_override.py
@@ -8,8 +8,6 @@ Covers two orthogonal features:
 
 from __future__ import annotations
 
-import pytest
-
 from plare.parser import Parser
 from plare.token import Token
 
@@ -185,7 +183,15 @@ def test_rr_equal_precedence_first_defined_wins() -> None:
     ParserError.  With it, first_val (defined earlier, lower definition_index)
     wins, so the reduction always produces FirstResult.
     """
-    grammar: dict = {
+    grammar: dict[
+        str,
+        list[
+            tuple[list[type[Token] | str], type[object] | None, list[int]]
+            | tuple[
+                list[type[Token] | str], type[object] | None, list[int], type[Token]
+            ]
+        ],
+    ] = {
         "result": [
             (["first_val"], FirstResult, [0]),
             (["second_val"], SecondResult, [0]),


### PR DESCRIPTION
## Summary

- Add `[tool.pyright] typeCheckingMode = "strict"` to `pyproject.toml`
- Remove `Any` import from `plare/parser.py`; replace `Any` with `object` in all `__eq__`/`__ne__` signatures
- Resolve generic `isinstance` narrowing issue in `State.__eq__` with an `is_instance(self, obj) -> TypeGuard[State[T]]` instance method — `T` is bound through `self: State[T]`, so `other.items` resolves to `set[Item[T]]`
- Fix bare `type` → `type[object]` in `Grammar` type alias (`test_determinism.py`)
- Fix `right: list` → `right: list[type[Token] | str]` (`test_hash_semantics.py`)
- Add full union type annotation to `grammar: dict` variable (`test_prec_override.py`)
- Remove unused `import pytest` (`test_prec_override.py`)

## Test plan

- [x] `python -m pyright` → 0 errors, 0 warnings
- [x] `python -m pytest tests/ -m "not slow"` → 32 passed