### PR TITLE
fix(token): default associative "right" to match yacc/bison shift-first behavior

### DIFF
--- a/plare/token.py
+++ b/plare/token.py
@@ -50,7 +50,7 @@ class Token:
         have different hashes.
     """
 
-    associative: assoc = "left"
+    associative: assoc = "right"
     precedence: int = 0
 
     def __init__(self, value: str, *, lineno: int, offset: int) -> None:

--- a/tests/test_grammar_logic.py
+++ b/tests/test_grammar_logic.py
@@ -241,7 +241,7 @@ def test_calc_mixed_left_assoc_same_precedence() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Section 2: Default S/R conflict is left-associative
+# Section 2: Explicit left-assoc declaration causes reduce to win in S/R conflict
 # ---------------------------------------------------------------------------
 
 
@@ -252,7 +252,7 @@ class NUM_SR(Token):
 
 
 class PLUS_SR(Token):
-    pass  # no precedence set → default 0, associative="left"
+    associative = "left"
 
 
 class NumSR:
@@ -267,15 +267,14 @@ class AddSR:
 
 
 def test_default_sr_conflict_is_left_associative() -> None:
-    """With no explicit precedence, S/R conflict resolves to reduce (left-associative).
+    """With explicit associative="left", S/R conflict resolves to reduce (left-associative).
 
     When both item.precedence and symbol.precedence are 0, the parser condition:
         item.precedence == symbol.precedence and symbol.associative == "left"
-    is True (Token default associative="left"), so reduce wins.
+    is True, so reduce wins.
 
     This means 1 + 2 + 3 produces a LEFT-leaning tree AddSR(AddSR(1, 2), 3),
-    not a right-leaning one. The existing test_shift_reduce_resolution_prefers_shift
-    only tests the two-token case and makes no tree-shape assertion.
+    not a right-leaning one.
     """
     p = Parser(
         {
@@ -349,13 +348,6 @@ class IfThenElseD(StmtD):
         self.else_ = else_
 
 
-@pytest.mark.xfail(
-    reason=(
-        "Default S/R resolution reduces (not shifts) when both precedences are 0 "
-        "and associative='left': else binds to the outer if instead of the inner if "
-        "as most languages (C, Java) expect."
-    )
-)
 def test_dangling_else_inner_if_gets_else() -> None:
     """The dangling-else problem: 'if c1 then if c2 then s1 else s2'.
 


### PR DESCRIPTION
## Summary

- `Token.associative` default changed from `"left"` to `"right"`
- Without an explicit precedence declaration, S/R conflicts now resolve
  to **shift** (matching yacc/bison behavior) instead of reduce
- Fixes the dangling-else problem: `if c1 then if c2 then s1 else s2`
  now correctly produces `IfThenD(c1, IfThenElseD(c2, s1, s2))`

## Root Cause

The S/R conflict resolution condition in `parser.py`:

```python
if item.precedence > symbol.precedence or (
    item.precedence == symbol.precedence
    and symbol.associative == "left"
):
    resolve to reduce
```

With the old `"left"` default, the second branch was always true at
precedence 0, so reduce always won — contradicting yacc/bison, which
defaults to shift when no declaration is present.

Migration
Grammars that relied on the implicit left-associativity of undeclared
tokens must now add an explicit `associative = "left"` to their token
class (as done for `PLUS_SR` in the test suite).

Test Plan
- [x] `test_dangling_else_inner_if_gets_else` — xfail removed, now passes
- [x] `test_default_sr_conflict_is_left_associative` — still passes with explicit `associative = "left"` on `PLUS_SR`
- [x] Full test suite: 61 passed
- [x] pyright: 0 errors